### PR TITLE
fix build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ Change log
 
 See `CHANGELOG <https://github.com/trustlines-protocol/watch/blob/master/CHANGELOG.rst>`_.
 
-
-.. |Build Status| image:: https://circleci.com/gh/trustlines-protocol/watch.svg?style=svg
-    :target: https://circleci.com/gh/trustlines-protocol/watch
+.. |Build Status| image:: https://circleci.com/gh/trustlines-protocol/watch/tree/master.svg?style=svg
+    :target: https://circleci.com/gh/trustlines-protocol/watch/tree/master
 .. |Code style: black| image:: https://img.shields.io/badge/code%20style-black-000000.svg
    :target: https://github.com/ambv/black


### PR DESCRIPTION
link to master branch instead of default. At the moment the default branch shows
'no build'. My guess is this would have been resolved with the next build on the
master branch anyway.