### PR TITLE
report syncing state as 'ok' or 'syncing'

### DIFF
--- a/tlwatch/jsonrpc.py
+++ b/tlwatch/jsonrpc.py
@@ -58,7 +58,7 @@ def watch_jsonrpc(url):
             {
                 "service": "jsonrpc.syncing",
                 "host": url,
-                "state": "true" if syncing else "false",
+                "state": "syncing" if syncing else "ok",
                 "ttl": 30,
             },
         ]


### PR DESCRIPTION
Previously we reported 'true' or 'false'. All other services already reported
'ok', when they are working as expected.