### PR TITLE
Increase log level for get website hash command

### DIFF
--- a/tlwatch/website.py
+++ b/tlwatch/website.py
@@ -82,6 +82,7 @@ def watch_website(url: str, original_hash: str):
 @click.command()
 @url_option
 def get_website_hash(url: str):
+    logging.basicConfig(level=logging.INFO)
     source_hash = calculate_website_source_hash(url)
     click.echo(source_hash)
 


### PR DESCRIPTION
I don't know if it is intended to set the logging per click command. I'm just following the structure of the other watcher modules.

Related to: #16