### PR TITLE
Change relay url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__
 .tox/
 .mypy_cache/
 .pytest_cache/
+/.idea

--- a/src/tlwatch/relay.py
+++ b/src/tlwatch/relay.py
@@ -11,12 +11,12 @@ logger = logging.getLogger(__name__)
 
 def watch_relay(url):
     host = urllib.parse.urlparse(url).netloc
-    networks_url = urllib.parse.urljoin(url, "/api/v1/networks")
+    version_url = urllib.parse.urljoin(url, "/api/v1/version")
     description = ""
     try:
-        if len(requests.get(networks_url, timeout=10).json()) == 0:
+        if "relay/v" not in requests.get(version_url, timeout=10).text:
             state = "error"
-            description = "no networks"
+            description = "Version endpoint returns no version."
         else:
             state = "ok"
     except KeyboardInterrupt:


### PR DESCRIPTION
In some situations users might be running the relay, but the networks endpoint is turned off like is the case of a messaging server. Because of that a more reliable way to monitor the relay is to actually look at the version endpoint.